### PR TITLE
Fix clock_gettime on FreeBSD/NetBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - Linux: Uses `runtime.nanotime`
 - Windows: Uses `QueryPerformanceCounter` [docs](https://msdn.microsoft.com/en-us/library/windows/desktop/ms644904(v=vs.85).aspx)
 - macOS: Uses `mach_absolute_time` [docs](https://developer.apple.com/library/content/qa/qa1398/_index.html) (requires CGO)
+- FreeBSD: Uses `clock_gettime(CLOCK_MONOTONIC)` [docs](https://www.freebsd.org/cgi/man.cgi?query=clock_gettime)
 
 ## About `runtime.nanotime`
 

--- a/clock_clock_gettime.go
+++ b/clock_clock_gettime.go
@@ -8,16 +8,12 @@ import (
 	"unsafe"
 )
 
-const (
-	clock_monotonic = 1
-)
-
-func monotime() int64 {
+func monotime() uint64 {
 	var ts syscall.Timespec
 
 	syscall.Syscall(syscall.SYS_CLOCK_GETTIME, clock_monotonic, uintptr(unsafe.Pointer(&ts)), 0)
 
-	return ts.Nano()
+	return uint64(ts.Nano())
 }
 
 func duration(start uint64, end uint64) time.Duration {

--- a/sys_freebsd.go
+++ b/sys_freebsd.go
@@ -1,0 +1,5 @@
+package monotime
+
+const (
+	clock_monotonic = 4
+)

--- a/sys_linux.go
+++ b/sys_linux.go
@@ -1,0 +1,5 @@
+package monotime
+
+const (
+	clock_monotonic = 1
+)

--- a/sys_netbsd.go
+++ b/sys_netbsd.go
@@ -1,0 +1,5 @@
+package monotime
+
+const (
+	clock_monotonic = 3
+)


### PR DESCRIPTION
- Fixes `clock_gettime` backend everywhere
- Uses right values for clock_monotonic on FreeBSD & NetBSD.

